### PR TITLE
1.修复打jar包后java.lang.NoClassDefFoundError: org/apache/flink/table/api/…

### DIFF
--- a/easy-flink-cdc-boot-starter/pom.xml
+++ b/easy-flink-cdc-boot-starter/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-clients_2.12</artifactId>
+            <artifactId>flink-clients_${scala.version}</artifactId>
             <version>${flink.version}</version>
             <exclusions>
                 <exclusion>
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java_2.12</artifactId>
+            <artifactId>flink-streaming-java_${scala.version}</artifactId>
             <version>${flink.version}</version>
             <exclusions>
                 <exclusion>
@@ -77,6 +77,11 @@
                     <groupId>org.slf4j</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.version}</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <!--mysql -cdc-->
         <dependency>


### PR DESCRIPTION
问题：
在打jar包后使用jar包启动的时候会报
java.lang.NoClassDefFoundError: org/apache/flink/table/api/TableException

解决：
1.新增依赖解决
2.调整版本号通配符
